### PR TITLE
fix: add missed confluent repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,8 +26,15 @@
     <packaging>jar</packaging>
 
     <properties>
-        <confluent.version>5.3.0-SNAPSHOT</confluent.version>
+        <confluent.version>5.3.0</confluent.version>
     </properties>
+
+    <repositories>
+        <repository>
+            <id>confluent</id>
+            <url>https://packages.confluent.io/maven/</url>
+        </repository>
+    </repositories>
 
     <dependencies>
         <dependency>


### PR DESCRIPTION
The build process fails because there are no reference to the confluent repository. This commit fixes this issue and also fixes `confluent.version` by providing actual one.