### PR TITLE
fix: override shadowed getters inherited from the parent class

### DIFF
--- a/src/main/java/com/canelmas/kafka/connect/FieldAndTimeBasedPartitioner.java
+++ b/src/main/java/com/canelmas/kafka/connect/FieldAndTimeBasedPartitioner.java
@@ -154,4 +154,14 @@ public final class FieldAndTimeBasedPartitioner<T> extends TimeBasedPartitioner<
             }
         }
     }
+
+    @Override
+    public long getPartitionDurationMs() {
+        return partitionDurationMs;
+    }
+
+    @Override
+    public TimestampExtractor getTimestampExtractor() {
+        return timestampExtractor;
+    }
 }


### PR DESCRIPTION
Because we override parent variables, we need to override getters as well. Otherwise, this will lead to the error `Partitioner is not an instance of TimeBasedPartitioner` because getter from the parent class will refer to the parent `timestampExtractor` instead of new one in the child.