### PR TITLE
Fixed casting value from value field of field partitioner from float …

### DIFF
--- a/src/main/java/com/canelmas/kafka/connect/FieldAndTimeBasedPartitioner.java
+++ b/src/main/java/com/canelmas/kafka/connect/FieldAndTimeBasedPartitioner.java
@@ -98,7 +98,7 @@ public final class FieldAndTimeBasedPartitioner<T> extends TimeBasedPartitioner<
 
                 if (value instanceof Struct || value instanceof Map) {
 
-                    final String partitionField = (String) DataUtils.getNestedFieldValue(value, fieldName);
+                    final String partitionField = String.valueOf(DataUtils.getNestedFieldValue(value, fieldName));
 
                     if (formatPath) {
                         builder.append(String.join(DELIMITER_EQ, fieldName, partitionField));


### PR DESCRIPTION
If the value of the custom partitioner field is an Long the casting to String throws the exception. 
"java.lang.ClassCastException: class java.lang.Long cannot be cast to class java.lang.String"
This code should fix it.